### PR TITLE
Fixed screw input numbers

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -670,21 +670,21 @@
             "name": "Screw",
             "key_name": "screw",
             "category": "crafting1",
-            "time": 4,
+            "time": 6,
             "ingredients": [
                 ["iron-rod", 1]
             ],
-            "product": ["screw", 6]
+            "product": ["screw", 4]
         },
         {
             "name": "Alternate: Screw",
             "key_name": "alt-screw",
             "category": "crafting1",
-            "time": 8,
+            "time": 24,
             "ingredients": [
-                ["iron-ingot", 2]
+                ["iron-ingot", 5]
             ],
-            "product": ["screw", 12]
+            "product": ["screw", 20]
         },
         {
             "name": "Alternate: Steel Screw",
@@ -694,7 +694,7 @@
             "ingredients": [
                 ["steel-beam", 1]
             ],
-            "product": ["screw", 36]
+            "product": ["screw", 52]
         },
         {
             "name": "Biomass",


### PR DESCRIPTION
I am pretty sure the website is currently wrong but I am not so sure if my changes really fix the problem.
Previous behavior: 1 constructor outputs 90 screws / minute with an input of 15 iron rods / minute
Expected behavior: 1 constructor outputs 40 screws / minute with an input of 10 iron rods / minute
https://satisfactory.gamepedia.com/index.php?title=Screw